### PR TITLE
DCES-639 Tool to prepare migration data

### DIFF
--- a/premigconcor/src/main/java/uk/gov/justice/laadces/premigconcor/Runner.java
+++ b/premigconcor/src/main/java/uk/gov/justice/laadces/premigconcor/Runner.java
@@ -6,13 +6,15 @@ import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
+import uk.gov.justice.laadces.premigconcor.dao.integration.CaseMigration;
 import uk.gov.justice.laadces.premigconcor.dao.integration.CaseMigrationRepository;
-import uk.gov.justice.laadces.premigconcor.dao.migration.MaatId;
-import uk.gov.justice.laadces.premigconcor.service.CsvOutputService;
 import uk.gov.justice.laadces.premigconcor.dao.maat.ConcorContributionRepository;
 import uk.gov.justice.laadces.premigconcor.dao.maat.FdcContributionRepository;
+import uk.gov.justice.laadces.premigconcor.dao.migration.MaatId;
 import uk.gov.justice.laadces.premigconcor.dao.migration.MigrationScopeRepository;
+import uk.gov.justice.laadces.premigconcor.service.CsvOutputService;
 
+import java.util.HashSet;
 import java.util.TreeSet;
 
 /**
@@ -30,24 +32,32 @@ class Runner implements ApplicationRunner {
     private final CsvOutputService csvOutputService;
 
     @Override
-    public void run(ApplicationArguments args) throws Exception {
+    public void run(final ApplicationArguments args) throws Exception {
         log.info("Entering run...");
-        var maatIds = migrationScopeRepository.findAll();
-        log.info("Queried {} maatIds from migration database", maatIds.size());
+        final var maatIds = migrationScopeRepository.findAll();
+        log.info("Found {} maatIds from migration database", maatIds.size());
 
-        var missingConcorMaatIds = new TreeSet<Long>();
-        var cmsConcor = concorContributionRepository.findLatestIdsByMaatIds(maatIds, missingConcorMaatIds);
-        log.info("Queried {} concor cases from maat database, {} missing", cmsConcor.size(), missingConcorMaatIds.size());
-        csvOutputService.writeCaseMigrations("/tmp/premigconcor-concorCases.csv", cmsConcor);
-        csvOutputService.writeMaatIds("/tmp/premigconcor-concorMissing.csv", MaatId.of(missingConcorMaatIds));
-        caseMigrationRepository.saveAll(cmsConcor);
+        final var foundConcors = new HashSet<CaseMigration>();
+        final var missingConcors = new TreeSet<Long>();
+        concorContributionRepository.addLatestIdsByMaatIds(maatIds, foundConcors, missingConcors);
+        log.info("Found {} concor cases from maat database, and missing {} maatIds", foundConcors.size(), missingConcors.size());
+        csvOutputService.writeCaseMigrations("/tmp/premigconcor-concorCases.csv", foundConcors);
+        csvOutputService.writeMaatIds("/tmp/premigconcor-concorMissing.csv", MaatId.of(missingConcors));
 
-        var missingFdcMaatIds = new TreeSet<Long>();
-        var cmsFdc = fdcContributionRepository.findLatestIdsByMaatIds(maatIds, missingFdcMaatIds);
-        log.info("Queried {} fdc cases from maat database, {} missing", cmsFdc.size(), missingFdcMaatIds.size());
-        csvOutputService.writeCaseMigrations("/tmp/premigconcor-fdcCases.csv", cmsFdc);
-        csvOutputService.writeMaatIds("/tmp/premigconcor-fdcMissing.csv", MaatId.of(missingFdcMaatIds));
-        caseMigrationRepository.saveAll(cmsFdc);
+        final var foundFdcs = new HashSet<CaseMigration>();
+        final var missingFdcs = new TreeSet<Long>();
+        fdcContributionRepository.addLatestIdsByMaatIds(maatIds, foundFdcs, missingFdcs);
+        log.info("Found {} fdc cases from maat database, and missing {} maatIds", foundFdcs.size(), missingFdcs.size());
+        csvOutputService.writeCaseMigrations("/tmp/premigconcor-fdcCases.csv", foundFdcs);
+        csvOutputService.writeMaatIds("/tmp/premigconcor-fdcMissing.csv", MaatId.of(missingFdcs));
+
+        final var found = new HashSet<CaseMigration>();
+        found.addAll(foundConcors);
+        found.addAll(foundFdcs);
+        log.info("Checking {} case-migrations for existing duplicates", found.size());
+        caseMigrationRepository.removeExisting(found);
+        log.info("Persisting {} non-duplicate case-migrations", found.size());
+        caseMigrationRepository.saveAll(found);
         log.info("Exiting run...");
     }
 }

--- a/premigconcor/src/main/java/uk/gov/justice/laadces/premigconcor/Runner.java
+++ b/premigconcor/src/main/java/uk/gov/justice/laadces/premigconcor/Runner.java
@@ -14,7 +14,7 @@ import uk.gov.justice.laadces.premigconcor.dao.migration.MaatId;
 import uk.gov.justice.laadces.premigconcor.dao.migration.MigrationScopeRepository;
 import uk.gov.justice.laadces.premigconcor.service.CsvOutputService;
 
-import java.util.HashSet;
+import java.util.HashSet; 
 import java.util.TreeSet;
 
 /**
@@ -25,6 +25,12 @@ import java.util.TreeSet;
 @RequiredArgsConstructor
 @Slf4j
 class Runner implements ApplicationRunner {
+    // File paths to write CSV output to (for validation).
+    private static final String PATH_CSV_OUTPUT_FOUND_CONCOR = "./premigconcor-concorCases.csv";
+    private static final String PATH_CSV_OUTPUT_MISSING_CONCOR = "./premigconcor-concorMissing.csv";
+    private static final String PATH_CSV_OUTPUT_FOUND_FDC = "./premigconcor-fdcCases.csv";
+    private static final String PATH_CSV_OUTPUT_MISSING_FDC = "./premigconcor-fdcMissing.csv";
+
     private final MigrationScopeRepository migrationScopeRepository;
     private final ConcorContributionRepository concorContributionRepository;
     private final FdcContributionRepository fdcContributionRepository;
@@ -41,15 +47,15 @@ class Runner implements ApplicationRunner {
         final var missingConcors = new TreeSet<Long>();
         concorContributionRepository.addLatestIdsByMaatIds(maatIds, foundConcors, missingConcors);
         log.info("Found {} concor cases from maat database, and missing {} maatIds", foundConcors.size(), missingConcors.size());
-        csvOutputService.writeCaseMigrations("/tmp/premigconcor-concorCases.csv", foundConcors);
-        csvOutputService.writeMaatIds("/tmp/premigconcor-concorMissing.csv", MaatId.of(missingConcors));
+        csvOutputService.writeCaseMigrations(PATH_CSV_OUTPUT_FOUND_CONCOR, foundConcors);
+        csvOutputService.writeMaatIds(PATH_CSV_OUTPUT_MISSING_CONCOR, MaatId.of(missingConcors));
 
         final var foundFdcs = new HashSet<CaseMigration>();
         final var missingFdcs = new TreeSet<Long>();
         fdcContributionRepository.addLatestIdsByMaatIds(maatIds, foundFdcs, missingFdcs);
         log.info("Found {} fdc cases from maat database, and missing {} maatIds", foundFdcs.size(), missingFdcs.size());
-        csvOutputService.writeCaseMigrations("/tmp/premigconcor-fdcCases.csv", foundFdcs);
-        csvOutputService.writeMaatIds("/tmp/premigconcor-fdcMissing.csv", MaatId.of(missingFdcs));
+        csvOutputService.writeCaseMigrations(PATH_CSV_OUTPUT_FOUND_FDC, foundFdcs);
+        csvOutputService.writeMaatIds(PATH_CSV_OUTPUT_MISSING_FDC, MaatId.of(missingFdcs));
 
         final var found = new HashSet<CaseMigration>();
         found.addAll(foundConcors);

--- a/premigconcor/src/main/java/uk/gov/justice/laadces/premigconcor/Runner.java
+++ b/premigconcor/src/main/java/uk/gov/justice/laadces/premigconcor/Runner.java
@@ -56,8 +56,10 @@ class Runner implements ApplicationRunner {
         found.addAll(foundFdcs);
         log.info("Checking {} case-migrations for existing duplicates", found.size());
         caseMigrationRepository.removeExisting(found);
+
         log.info("Persisting {} non-duplicate case-migrations", found.size());
         caseMigrationRepository.saveAll(found);
+
         log.info("Exiting run...");
     }
 }

--- a/premigconcor/src/main/java/uk/gov/justice/laadces/premigconcor/config/DataSourceConfig.java
+++ b/premigconcor/src/main/java/uk/gov/justice/laadces/premigconcor/config/DataSourceConfig.java
@@ -7,35 +7,19 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.simple.JdbcClient;
 
 import javax.sql.DataSource;
 
 /**
- * Configure some qualified datasources for the three databases.
+ * Configure some qualified data sources for the three databases.
  */
 @Configuration
 public class DataSourceConfig {
-
-    @Bean
-    @Primary
-    @ConfigurationProperties("spring.datasource")
-    public DataSourceProperties integrationDataSourceProperties() {
-        return new DataSourceProperties();
-    }
-
-    @Bean
-    @Primary
-    public HikariDataSource integrationDataSource(@Qualifier("integrationDataSourceProperties") DataSourceProperties integrationDataSourceProperties) {
-        return integrationDataSourceProperties.initializeDataSourceBuilder().type(HikariDataSource.class).build();
-    }
-
-    @Bean
-    @Primary
-    public JdbcClient integrationJdbcClient(@Qualifier("integrationDataSource") DataSource integrationDataSource) {
-        return JdbcClient.create(integrationDataSource);
-    }
-
+    /**
+     * The migration data source - used to query the source maatIds.
+     */
     @Bean
     @ConfigurationProperties("migration.datasource")
     public DataSourceProperties migrationDataSourceProperties() {
@@ -52,6 +36,9 @@ public class DataSourceConfig {
         return JdbcClient.create(migrationDataSource);
     }
 
+    /**
+     * The maat data source - used to query translation of source maatIds into target contribution Ids.
+     */
     @Bean
     @ConfigurationProperties("maat.datasource")
     public DataSourceProperties maatDataSourceProperties() {
@@ -66,5 +53,30 @@ public class DataSourceConfig {
     @Bean
     public JdbcClient maatJdbcClient(@Qualifier("maatDataSource") DataSource maatDataSource) {
         return JdbcClient.create(maatDataSource);
+    }
+
+    /**
+     * The integration data source - used to insert the generated target contribution Ids.
+     */
+    @Bean
+    @Primary
+    @ConfigurationProperties("spring.datasource")
+    public DataSourceProperties integrationDataSourceProperties() {
+        return new DataSourceProperties();
+    }
+
+    @Bean
+    @Primary
+    public HikariDataSource integrationDataSource(@Qualifier("integrationDataSourceProperties") DataSourceProperties integrationDataSourceProperties) {
+        return integrationDataSourceProperties.initializeDataSourceBuilder().type(HikariDataSource.class).build();
+    }
+
+    /**
+     * We need this to batch insert (because JdbcClient can't do batch inserts or batch updates).
+     */
+    @Bean
+    @Primary
+    public JdbcTemplate integrationJdbcTemplate(@Qualifier("integrationDataSource") DataSource integrationDataSource) {
+        return new JdbcTemplate(integrationDataSource);
     }
 }

--- a/premigconcor/src/main/java/uk/gov/justice/laadces/premigconcor/dao/integration/CaseMigration.java
+++ b/premigconcor/src/main/java/uk/gov/justice/laadces/premigconcor/dao/integration/CaseMigration.java
@@ -1,6 +1,7 @@
 package uk.gov.justice.laadces.premigconcor.dao.integration;
 
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 public record CaseMigration(long maatId                 /* required */,
                             String recordType           /* required */,
@@ -18,5 +19,30 @@ public record CaseMigration(long maatId                 /* required */,
 
     public static CaseMigration ofFdcContribution(long maatId, long fdcId, Long batchId) {
         return new CaseMigration(maatId, "Fdc", 0, fdcId, batchId, Boolean.FALSE, null, null, null);
+    }
+
+    public static CaseMigration ofPrimaryKey(long maatId, long concorContributionId, long fdcId) {
+        return new CaseMigration(maatId, concorContributionId != 0 ? "Contribution" : "Fdc", concorContributionId, fdcId, null, null, null, null, null);
+    }
+
+    /**
+     * Implementation of equals() that ignores every record component except (maatId, concorContributionId, fdcId),
+     * which is the primary key in the table. Annoying as one reason to use records was to avoid writing this.
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof CaseMigration other) {
+            return maatId == other.maatId && concorContributionId == other.concorContributionId && fdcId == other.fdcId;
+        }
+        return false;
+    }
+
+    /**
+     * Implementation of hashCode() that ignores every record component except (maatId, concorContributionId, fdcId),
+     * which is the primary key in the table. Annoying as one reason to use records was to avoid writing this.
+     */
+    @Override
+    public int hashCode() {
+        return Objects.hash(maatId, concorContributionId, fdcId);
     }
 }

--- a/premigconcor/src/main/java/uk/gov/justice/laadces/premigconcor/dao/integration/CaseMigration.java
+++ b/premigconcor/src/main/java/uk/gov/justice/laadces/premigconcor/dao/integration/CaseMigration.java
@@ -6,17 +6,17 @@ public record CaseMigration(long maatId                 /* required */,
                             String recordType           /* required */,
                             Long concorContributionId   /* null-or-id */,
                             Long fdcId                  /* null-or-id */,
-                            int batchId                 /* vary */,
+                            Long batchId                /* vary */,
                             boolean isProcessed         /* false */,
                             LocalDateTime processedDate /* null */,
                             Integer httpStatus          /* null */,
                             String payload              /* null */) {
 
-    public static CaseMigration ofConcorContribution(long maatId, long concorContributionId, int batchId) {
+    public static CaseMigration ofConcorContribution(long maatId, long concorContributionId, Long batchId) {
         return new CaseMigration(maatId, "Contribution", concorContributionId, null, batchId, false, null, null, null);
     }
 
-    public static CaseMigration ofFdcContribution(long maatId, long fdcId, int batchId) {
+    public static CaseMigration ofFdcContribution(long maatId, long fdcId, Long batchId) {
         return new CaseMigration(maatId, "Fdc", null, fdcId, batchId, false, null, null, null);
     }
 }

--- a/premigconcor/src/main/java/uk/gov/justice/laadces/premigconcor/dao/integration/CaseMigration.java
+++ b/premigconcor/src/main/java/uk/gov/justice/laadces/premigconcor/dao/integration/CaseMigration.java
@@ -4,19 +4,19 @@ import java.time.LocalDateTime;
 
 public record CaseMigration(long maatId                 /* required */,
                             String recordType           /* required */,
-                            Long concorContributionId   /* null-or-id */,
-                            Long fdcId                  /* null-or-id */,
+                            long concorContributionId   /* null-or-id */,
+                            long fdcId                  /* null-or-id */,
                             Long batchId                /* vary */,
-                            boolean isProcessed         /* false */,
+                            Boolean isProcessed         /* false */,
                             LocalDateTime processedDate /* null */,
                             Integer httpStatus          /* null */,
                             String payload              /* null */) {
 
     public static CaseMigration ofConcorContribution(long maatId, long concorContributionId, Long batchId) {
-        return new CaseMigration(maatId, "Contribution", concorContributionId, null, batchId, false, null, null, null);
+        return new CaseMigration(maatId, "Contribution", concorContributionId, 0, batchId, Boolean.FALSE, null, null, null);
     }
 
     public static CaseMigration ofFdcContribution(long maatId, long fdcId, Long batchId) {
-        return new CaseMigration(maatId, "Fdc", null, fdcId, batchId, false, null, null, null);
+        return new CaseMigration(maatId, "Fdc", 0, fdcId, batchId, Boolean.FALSE, null, null, null);
     }
 }

--- a/premigconcor/src/main/java/uk/gov/justice/laadces/premigconcor/dao/integration/CaseMigrationRepository.java
+++ b/premigconcor/src/main/java/uk/gov/justice/laadces/premigconcor/dao/integration/CaseMigrationRepository.java
@@ -2,48 +2,59 @@ package uk.gov.justice.laadces.premigconcor.dao.integration;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 
-import java.sql.Types;
-import java.util.List;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.Collection;
 
 @Repository
 @Slf4j
 public class CaseMigrationRepository {
-    private final JdbcClient integration;
+    private static final int BATCH_SIZE = 990;
+    private final JdbcTemplate integration;
 
-    public CaseMigrationRepository(@Qualifier("integrationJdbcClient") final JdbcClient integration) {
+    public CaseMigrationRepository(@Qualifier("integrationJdbcTemplate") final JdbcTemplate integration) {
         this.integration = integration;
     }
 
-    public void saveAll(final List<CaseMigration> caseMigrations) {
-        for (CaseMigration caseMigration : caseMigrations) {
-            try {
-                save(caseMigration);
-            } catch (Exception e) {
-                log.warn("Could not save {}", caseMigration, e);
+    public void removeExisting(final Collection<CaseMigration> caseMigrations) {
+        final int originalSize = caseMigrations.size();
+        final var counts = new Object() { // need to be 'effectively final' to access from lambda.
+            int total = 0;
+            int removed = 0;
+        };
+        integration.query("""
+                SELECT maat_id, concor_contribution_id, fdc_id
+                FROM case_migration
+                """, rs -> {
+            final var caseMigration = CaseMigration.ofPrimaryKey(rs.getLong(1), rs.getLong(2), rs.getLong(3));
+            ++counts.total;
+            if (caseMigrations.remove(caseMigration)) {
+                ++counts.removed;
             }
-        }
+        });
+        log.info("Removed {} of {} original case-migrations", counts.removed, originalSize);
+        log.info("Remaining {} case-migrations are distinct from the {} already in the database", caseMigrations.size(), counts.total);
     }
 
-    public void save(final CaseMigration caseMigration) {
-        final String sql = """
-                INSERT INTO case_migration
-                    (maat_id, record_type, concor_contribution_id, fdc_id, batch_id, is_processed, processed_date, http_status, payload)
-                VALUES
-                    (:maatId, :recordType, :concorContributionId, :fdcId, :batchId, :isProcessed, :processedDate, :httpStatus, :payload)
-                """;
-        int noOfrowsAffected = integration.sql(sql)
-                .param("maatId", caseMigration.maatId(), Types.INTEGER)
-                .param("recordType", caseMigration.recordType(), Types.VARCHAR)
-                .param("concorContributionId", caseMigration.concorContributionId(), Types.INTEGER)
-                .param("fdcId", caseMigration.fdcId(), Types.INTEGER)
-                .param("batchId", caseMigration.batchId(), Types.INTEGER)
-                .param("isProcessed", caseMigration.isProcessed(), Types.BOOLEAN)
-                .param("processedDate", caseMigration.processedDate(), Types.TIMESTAMP)
-                .param("httpStatus", caseMigration.httpStatus(), Types.INTEGER)
-                .param("payload", caseMigration.payload(), Types.VARCHAR)
-                .update();
+    public void saveAll(final Collection<CaseMigration> caseMigrations) {
+        integration.batchUpdate("""
+                INSERT INTO case_migration (maat_id, record_type, concor_contribution_id, fdc_id,
+                                            batch_id, is_process, processed_date, http_status, payload)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """, caseMigrations, BATCH_SIZE, (stmt, caseMigration) -> {
+            stmt.setLong(1, caseMigration.maatId());
+            stmt.setString(2, caseMigration.recordType());
+            stmt.setLong(3, caseMigration.concorContributionId());
+            stmt.setLong(4, caseMigration.fdcId());
+            stmt.setLong(5, caseMigration.batchId());
+            stmt.setBoolean(6, caseMigration.isProcessed());
+            final LocalDateTime processedDate = caseMigration.processedDate();
+            stmt.setTimestamp(7, processedDate != null ? Timestamp.valueOf(processedDate) : null);
+            stmt.setInt(8, caseMigration.httpStatus());
+            stmt.setString(9, caseMigration.payload());
+        });
     }
 }

--- a/premigconcor/src/main/java/uk/gov/justice/laadces/premigconcor/dao/integration/CaseMigrationRepository.java
+++ b/premigconcor/src/main/java/uk/gov/justice/laadces/premigconcor/dao/integration/CaseMigrationRepository.java
@@ -1,0 +1,49 @@
+package uk.gov.justice.laadces.premigconcor.dao.integration;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.stereotype.Repository;
+
+import java.sql.Types;
+import java.util.List;
+
+@Repository
+@Slf4j
+public class CaseMigrationRepository {
+    private final JdbcClient integration;
+
+    public CaseMigrationRepository(@Qualifier("integrationJdbcClient") final JdbcClient integration) {
+        this.integration = integration;
+    }
+
+    public void saveAll(final List<CaseMigration> caseMigrations) {
+        for (CaseMigration caseMigration : caseMigrations) {
+            try {
+                save(caseMigration);
+            } catch (Exception e) {
+                log.warn("Could not save {}", caseMigration, e);
+            }
+        }
+    }
+
+    public void save(final CaseMigration caseMigration) {
+        final String sql = """
+                INSERT INTO case_migration
+                    (maat_id, record_type, concor_contribution_id, fdc_id, batch_id, is_processed, processed_date, http_status, payload)
+                VALUES
+                    (:maatId, :recordType, :concorContributionId, :fdcId, :batchId, :isProcessed, :processedDate, :httpStatus, :payload)
+                """;
+        int noOfrowsAffected = integration.sql(sql)
+                .param("maatId", caseMigration.maatId(), Types.INTEGER)
+                .param("recordType", caseMigration.recordType(), Types.VARCHAR)
+                .param("concorContributionId", caseMigration.concorContributionId(), Types.INTEGER)
+                .param("fdcId", caseMigration.fdcId(), Types.INTEGER)
+                .param("batchId", caseMigration.batchId(), Types.INTEGER)
+                .param("isProcessed", caseMigration.isProcessed(), Types.BOOLEAN)
+                .param("processedDate", caseMigration.processedDate(), Types.TIMESTAMP)
+                .param("httpStatus", caseMigration.httpStatus(), Types.INTEGER)
+                .param("payload", caseMigration.payload(), Types.VARCHAR)
+                .update();
+    }
+}

--- a/premigconcor/src/main/java/uk/gov/justice/laadces/premigconcor/dao/maat/ConcorContributionRepository.java
+++ b/premigconcor/src/main/java/uk/gov/justice/laadces/premigconcor/dao/maat/ConcorContributionRepository.java
@@ -9,6 +9,7 @@ import uk.gov.justice.laadces.premigconcor.dao.integration.CaseMigration;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.TreeSet;
 
 @Repository
@@ -21,7 +22,7 @@ public class ConcorContributionRepository {
         this.maat = maat;
     }
 
-    public List<CaseMigration> findLatestIdsByMaatIds(List<Long> maatIds) {
+    public List<CaseMigration> findLatestIdsByMaatIds(final List<Long> maatIds, final Set<Long> missing) {
         final int count = maatIds.size();
         final var cms = new ArrayList<CaseMigration>(count);
         for (int i = 0; i < count; i += BATCH_SIZE) {
@@ -34,11 +35,12 @@ public class ConcorContributionRepository {
                         final long concorContributionId = rs.getLong(1);
                         final long maatId = rs.getLong(2);
                         set.remove(maatId);
-                        return CaseMigration.ofConcorContribution(concorContributionId, maatId, rowNum);
+                        return CaseMigration.ofConcorContribution(concorContributionId, maatId, (long) rowNum);
                     })
                     .list());
             if (!set.isEmpty()) {
                 log.warn("{} maatIds were not found: {}", set.size(), set);
+                missing.addAll(set);
             }
         }
         return cms;

--- a/premigconcor/src/main/java/uk/gov/justice/laadces/premigconcor/dao/maat/ConcorContributionRepository.java
+++ b/premigconcor/src/main/java/uk/gov/justice/laadces/premigconcor/dao/maat/ConcorContributionRepository.java
@@ -35,7 +35,7 @@ public class ConcorContributionRepository {
                         final long concorContributionId = rs.getLong(1);
                         final long maatId = rs.getLong(2);
                         set.remove(maatId);
-                        return CaseMigration.ofConcorContribution(concorContributionId, maatId, (long) rowNum);
+                        return CaseMigration.ofConcorContribution(maatId, concorContributionId, (long) rowNum);
                     })
                     .list());
             if (!set.isEmpty()) {

--- a/premigconcor/src/main/java/uk/gov/justice/laadces/premigconcor/dao/maat/ConcorContributionRepository.java
+++ b/premigconcor/src/main/java/uk/gov/justice/laadces/premigconcor/dao/maat/ConcorContributionRepository.java
@@ -1,19 +1,16 @@
 package uk.gov.justice.laadces.premigconcor.dao.maat;
 
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.simple.JdbcClient;
 import org.springframework.stereotype.Repository;
 import uk.gov.justice.laadces.premigconcor.dao.integration.CaseMigration;
 
-import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
-import java.util.Set;
 import java.util.TreeSet;
 
 @Repository
-@Slf4j
 public class ConcorContributionRepository {
     private static final int BATCH_SIZE = 990;
     private final JdbcClient maat;
@@ -22,14 +19,18 @@ public class ConcorContributionRepository {
         this.maat = maat;
     }
 
-    public List<CaseMigration> findLatestIdsByMaatIds(final List<Long> maatIds, final Set<Long> missing) {
+    public void addLatestIdsByMaatIds(final List<Long> maatIds, final Collection<CaseMigration> foundConcors, final Collection<Long> missingConcors) {
         final int count = maatIds.size();
-        final var cms = new ArrayList<CaseMigration>(count);
         for (int i = 0; i < count; i += BATCH_SIZE) {
             final var subList = maatIds.subList(i, Math.min(count, i + BATCH_SIZE));
             final var paramSource = new MapSqlParameterSource("maatIds", subList);
             final var set = new TreeSet<>(subList);
-            cms.addAll(maat.sql("SELECT MAX(id), rep_id FROM togdata.concor_contributions WHERE rep_id IN (:maatIds) AND status = 'SENT' GROUP BY rep_id ORDER BY rep_id")
+            foundConcors.addAll(maat.sql("""
+                            SELECT MAX(id), rep_id
+                            FROM togdata.concor_contributions
+                            WHERE rep_id IN (:maatIds) AND status = 'SENT'
+                            GROUP BY rep_id
+                            """)
                     .paramSource(paramSource)
                     .query((rs, rowNum) -> {
                         final long concorContributionId = rs.getLong(1);
@@ -39,10 +40,8 @@ public class ConcorContributionRepository {
                     })
                     .list());
             if (!set.isEmpty()) {
-                log.warn("{} maatIds were not found: {}", set.size(), set);
-                missing.addAll(set);
+                missingConcors.addAll(set);
             }
         }
-        return cms;
     }
 }

--- a/premigconcor/src/main/java/uk/gov/justice/laadces/premigconcor/dao/maat/FdcContributionRepository.java
+++ b/premigconcor/src/main/java/uk/gov/justice/laadces/premigconcor/dao/maat/FdcContributionRepository.java
@@ -29,7 +29,7 @@ public class FdcContributionRepository {
                         SELECT MAX(id), rep_id
                         FROM togdata.fdc_contributions
                         WHERE rep_id IN (:maatIds)
-                        GROUP BY rep_i
+                        GROUP BY rep_id
                         """)
                     .paramSource(paramSource)
                     .query((rs, rowNum) -> {

--- a/premigconcor/src/main/java/uk/gov/justice/laadces/premigconcor/dao/maat/FdcContributionRepository.java
+++ b/premigconcor/src/main/java/uk/gov/justice/laadces/premigconcor/dao/maat/FdcContributionRepository.java
@@ -9,6 +9,7 @@ import uk.gov.justice.laadces.premigconcor.dao.integration.CaseMigration;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.TreeSet;
 
 @Repository
@@ -21,7 +22,7 @@ public class FdcContributionRepository {
         this.maat = maat;
     }
 
-    public List<CaseMigration> findLatestIdsByMaatIds(final List<Long> maatIds) {
+    public List<CaseMigration> findLatestIdsByMaatIds(final List<Long> maatIds, final Set<Long> missing) {
         final int count = maatIds.size();
         final var cms = new ArrayList<CaseMigration>(count);
         for (int i = 0; i < count; i += BATCH_SIZE) {
@@ -34,11 +35,12 @@ public class FdcContributionRepository {
                         final long fdcId = rs.getLong(1);
                         final long maatId = rs.getLong(2);
                         set.remove(maatId);
-                        return CaseMigration.ofFdcContribution(fdcId, maatId, rowNum);
+                        return CaseMigration.ofFdcContribution(fdcId, maatId, (long) rowNum);
                     })
                     .list());
             if (!set.isEmpty()) {
                 log.warn("{} maatIds were not found: {}", set.size(), set);
+                missing.addAll(set);
             }
         }
         return cms;

--- a/premigconcor/src/main/java/uk/gov/justice/laadces/premigconcor/dao/maat/FdcContributionRepository.java
+++ b/premigconcor/src/main/java/uk/gov/justice/laadces/premigconcor/dao/maat/FdcContributionRepository.java
@@ -35,7 +35,7 @@ public class FdcContributionRepository {
                         final long fdcId = rs.getLong(1);
                         final long maatId = rs.getLong(2);
                         set.remove(maatId);
-                        return CaseMigration.ofFdcContribution(fdcId, maatId, (long) rowNum);
+                        return CaseMigration.ofFdcContribution(maatId, fdcId, (long) rowNum);
                     })
                     .list());
             if (!set.isEmpty()) {

--- a/premigconcor/src/main/java/uk/gov/justice/laadces/premigconcor/dao/maat/FdcContributionRepository.java
+++ b/premigconcor/src/main/java/uk/gov/justice/laadces/premigconcor/dao/maat/FdcContributionRepository.java
@@ -1,19 +1,16 @@
 package uk.gov.justice.laadces.premigconcor.dao.maat;
 
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.simple.JdbcClient;
 import org.springframework.stereotype.Repository;
 import uk.gov.justice.laadces.premigconcor.dao.integration.CaseMigration;
 
-import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
-import java.util.Set;
 import java.util.TreeSet;
 
 @Repository
-@Slf4j
 public class FdcContributionRepository {
     private static final int BATCH_SIZE = 990;
     private final JdbcClient maat;
@@ -22,14 +19,18 @@ public class FdcContributionRepository {
         this.maat = maat;
     }
 
-    public List<CaseMigration> findLatestIdsByMaatIds(final List<Long> maatIds, final Set<Long> missing) {
+    public void addLatestIdsByMaatIds(final List<Long> maatIds, final Collection<CaseMigration> foundFdcs, final Collection<Long> missingFdcs) {
         final int count = maatIds.size();
-        final var cms = new ArrayList<CaseMigration>(count);
         for (int i = 0; i < count; i += BATCH_SIZE) {
             final var subList = maatIds.subList(i, Math.min(count, i + BATCH_SIZE));
             final var paramSource = new MapSqlParameterSource("maatIds", subList);
             final var set = new TreeSet<>(subList);
-            cms.addAll(maat.sql("SELECT MAX(id), rep_id FROM togdata.fdc_contributions WHERE rep_id IN (:maatIds) GROUP BY rep_id ORDER BY rep_id")
+            foundFdcs.addAll(maat.sql("""
+                        SELECT MAX(id), rep_id
+                        FROM togdata.fdc_contributions
+                        WHERE rep_id IN (:maatIds)
+                        GROUP BY rep_i
+                        """)
                     .paramSource(paramSource)
                     .query((rs, rowNum) -> {
                         final long fdcId = rs.getLong(1);
@@ -39,10 +40,8 @@ public class FdcContributionRepository {
                     })
                     .list());
             if (!set.isEmpty()) {
-                log.warn("{} maatIds were not found: {}", set.size(), set);
-                missing.addAll(set);
+                missingFdcs.addAll(set);
             }
         }
-        return cms;
     }
 }

--- a/premigconcor/src/main/java/uk/gov/justice/laadces/premigconcor/dao/migration/MaatId.java
+++ b/premigconcor/src/main/java/uk/gov/justice/laadces/premigconcor/dao/migration/MaatId.java
@@ -1,7 +1,7 @@
 package uk.gov.justice.laadces.premigconcor.dao.migration;
 
+import java.util.Collection;
 import java.util.List;
-import java.util.Set;
 
 /**
  * Exists purely to output as CSV, this class is probably completely unnecessary.
@@ -9,7 +9,7 @@ import java.util.Set;
  * @param maatId A numeric maatId
  */
 public record MaatId(long maatId) {
-    public static List<MaatId> of(Set<Long> maatIds) {
+    public static List<MaatId> of(Collection<Long> maatIds) {
         return maatIds.stream().map(MaatId::new).toList();
     }
 }

--- a/premigconcor/src/main/java/uk/gov/justice/laadces/premigconcor/dao/migration/MaatId.java
+++ b/premigconcor/src/main/java/uk/gov/justice/laadces/premigconcor/dao/migration/MaatId.java
@@ -1,0 +1,15 @@
+package uk.gov.justice.laadces.premigconcor.dao.migration;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Exists purely to output as CSV, this class is probably completely unnecessary.
+ *
+ * @param maatId A numeric maatId
+ */
+public record MaatId(long maatId) {
+    public static List<MaatId> of(Set<Long> maatIds) {
+        return maatIds.stream().map(MaatId::new).toList();
+    }
+}

--- a/premigconcor/src/main/java/uk/gov/justice/laadces/premigconcor/dao/migration/MigrationScopeRepository.java
+++ b/premigconcor/src/main/java/uk/gov/justice/laadces/premigconcor/dao/migration/MigrationScopeRepository.java
@@ -15,7 +15,11 @@ public class MigrationScopeRepository {
     }
 
     public List<Long> findAll() {
-        // varchar column that may contain junk.
-        return migration.sql("SELECT DISTINCT CAST(maatid AS INTEGER) FROM marston.migrationscope WHERE maatid ~ '^[1-9][0-9]*$' ORDER BY 1").query(Long.class).list();
+        // varchar column that may contain junk; no need to order as would not be numeric order anyway.
+        return migration.sql("""
+                SELECT DISTINCT CAST(clientcasereference AS INTEGER) AS maat_id
+                FROM transform.laacasedetails
+                WHERE clientcasereference ~ '^[1-9][0-9]*$'
+                """).query(Long.class).list();
     }
 }

--- a/premigconcor/src/main/java/uk/gov/justice/laadces/premigconcor/service/CaseMigrationComponentComparator.java
+++ b/premigconcor/src/main/java/uk/gov/justice/laadces/premigconcor/service/CaseMigrationComponentComparator.java
@@ -1,4 +1,6 @@
-package uk.gov.justice.laadces.premigconcor.dao.integration;
+package uk.gov.justice.laadces.premigconcor.service;
+
+import uk.gov.justice.laadces.premigconcor.dao.integration.CaseMigration;
 
 import java.lang.reflect.RecordComponent;
 import java.util.ArrayList;

--- a/premigconcor/src/main/java/uk/gov/justice/laadces/premigconcor/service/CsvOutputService.java
+++ b/premigconcor/src/main/java/uk/gov/justice/laadces/premigconcor/service/CsvOutputService.java
@@ -1,10 +1,12 @@
-package uk.gov.justice.laadces.premigconcor.dao.integration;
+package uk.gov.justice.laadces.premigconcor.service;
 
 import com.opencsv.bean.HeaderColumnNameMappingStrategy;
 import com.opencsv.bean.StatefulBeanToCsvBuilder;
 import com.opencsv.exceptions.CsvFieldAssignmentException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import uk.gov.justice.laadces.premigconcor.dao.integration.CaseMigration;
+import uk.gov.justice.laadces.premigconcor.dao.migration.MaatId;
 
 import java.io.FileWriter;
 import java.io.IOException;
@@ -30,6 +32,20 @@ public class CsvOutputService {
             writer.close();
         } catch (IOException | CsvFieldAssignmentException e) {
             throw new IllegalArgumentException("Failed to write CSV case-migrations file: " + filename, e);
+        }
+    }
+
+    public void writeMaatIds(final String filename, final List<MaatId> maatIds) {
+        final FileWriter writer;
+        try {
+            writer = new FileWriter(filename);
+            final var beanToCsv = new StatefulBeanToCsvBuilder<MaatId>(writer)
+                    .withQuotechar(NO_QUOTE_CHARACTER)
+                    .build();
+            beanToCsv.write(maatIds);
+            writer.close();
+        } catch (IOException | CsvFieldAssignmentException e) {
+            throw new IllegalArgumentException("Failed to write CSV maat-ids file: " + filename, e);
         }
     }
 }

--- a/premigconcor/src/main/java/uk/gov/justice/laadces/premigconcor/service/CsvOutputService.java
+++ b/premigconcor/src/main/java/uk/gov/justice/laadces/premigconcor/service/CsvOutputService.java
@@ -10,6 +10,7 @@ import uk.gov.justice.laadces.premigconcor.dao.migration.MaatId;
 
 import java.io.FileWriter;
 import java.io.IOException;
+import java.util.Collection;
 import java.util.List;
 
 import static com.opencsv.ICSVWriter.NO_QUOTE_CHARACTER;
@@ -17,7 +18,7 @@ import static com.opencsv.ICSVWriter.NO_QUOTE_CHARACTER;
 @RequiredArgsConstructor
 @Service
 public class CsvOutputService {
-    public void writeCaseMigrations(final String filename, final List<CaseMigration> caseMigrations) {
+    public void writeCaseMigrations(final String filename, final Collection<CaseMigration> caseMigrations) {
         final FileWriter writer;
         try {
             writer = new FileWriter(filename);
@@ -28,7 +29,7 @@ public class CsvOutputService {
                     .withMappingStrategy(strategy)
                     .withQuotechar(NO_QUOTE_CHARACTER)
                     .build();
-            beanToCsv.write(caseMigrations);
+            beanToCsv.write(caseMigrations.iterator());
             writer.close();
         } catch (IOException | CsvFieldAssignmentException e) {
             throw new IllegalArgumentException("Failed to write CSV case-migrations file: " + filename, e);


### PR DESCRIPTION
DCES-639 Tool to prepare migration data
- Output missing maatIds to extra CSV files
- Add saving to DRC integration database
- Correct parameter order when creating case_migrations
- Avoid persisting existing case-migrations
- Fix typo and null updates
- CSV output filenames at top