### PR TITLE
Delete unprocessed records to avoid having multiple migrations per-maatId

### DIFF
--- a/premigconcor/src/main/java/uk/gov/justice/laadces/premigconcor/Runner.java
+++ b/premigconcor/src/main/java/uk/gov/justice/laadces/premigconcor/Runner.java
@@ -14,7 +14,7 @@ import uk.gov.justice.laadces.premigconcor.dao.migration.MaatId;
 import uk.gov.justice.laadces.premigconcor.dao.migration.MigrationScopeRepository;
 import uk.gov.justice.laadces.premigconcor.service.CsvOutputService;
 
-import java.util.HashSet; 
+import java.util.HashSet;
 import java.util.TreeSet;
 
 /**
@@ -56,6 +56,9 @@ class Runner implements ApplicationRunner {
         log.info("Found {} fdc cases from maat database, and missing {} maatIds", foundFdcs.size(), missingFdcs.size());
         csvOutputService.writeCaseMigrations(PATH_CSV_OUTPUT_FOUND_FDC, foundFdcs);
         csvOutputService.writeMaatIds(PATH_CSV_OUTPUT_MISSING_FDC, MaatId.of(missingFdcs));
+
+        log.info("Checking {} maatIds for unprocessed case-migrations", maatIds.size());
+        caseMigrationRepository.deleteUnprocessed(maatIds);
 
         final var found = new HashSet<CaseMigration>();
         found.addAll(foundConcors);

--- a/premigconcor/src/main/java/uk/gov/justice/laadces/premigconcor/config/DataSourceConfig.java
+++ b/premigconcor/src/main/java/uk/gov/justice/laadces/premigconcor/config/DataSourceConfig.java
@@ -7,7 +7,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
-import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.simple.JdbcClient;
 
 import javax.sql.DataSource;
@@ -76,7 +76,7 @@ public class DataSourceConfig {
      */
     @Bean
     @Primary
-    public JdbcTemplate integrationJdbcTemplate(@Qualifier("integrationDataSource") DataSource integrationDataSource) {
-        return new JdbcTemplate(integrationDataSource);
+    public NamedParameterJdbcTemplate integrationNamedParameterJdbcTemplate(@Qualifier("integrationDataSource") DataSource integrationDataSource) {
+        return new NamedParameterJdbcTemplate(integrationDataSource);
     }
 }

--- a/premigconcor/src/main/java/uk/gov/justice/laadces/premigconcor/dao/integration/CaseMigrationRepository.java
+++ b/premigconcor/src/main/java/uk/gov/justice/laadces/premigconcor/dao/integration/CaseMigrationRepository.java
@@ -47,7 +47,7 @@ public class CaseMigrationRepository {
      * @return A list of lists (each of size partitionSize, except perhaps the last).
      * @param <T> The type of the list.
      */
-    private <T> List<List<T>> partition(final List<T> input, final int partitionSize) {
+    <T> List<List<T>> partition(final List<T> input, final int partitionSize) {
         if (partitionSize < 1) {
             throw new IllegalArgumentException("partitionSize must be >= 1");
         }

--- a/premigconcor/src/main/java/uk/gov/justice/laadces/premigconcor/dao/integration/CaseMigrationRepository.java
+++ b/premigconcor/src/main/java/uk/gov/justice/laadces/premigconcor/dao/integration/CaseMigrationRepository.java
@@ -2,22 +2,61 @@ package uk.gov.justice.laadces.premigconcor.dao.integration;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Repository;
 
 import java.sql.Timestamp;
 import java.sql.Types;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 
 @Repository
 @Slf4j
 public class CaseMigrationRepository {
     private static final int BATCH_SIZE = 990;
-    private final JdbcTemplate integration;
+    private final NamedParameterJdbcTemplate integration;
 
-    public CaseMigrationRepository(@Qualifier("integrationJdbcTemplate") final JdbcTemplate integration) {
+    public CaseMigrationRepository(@Qualifier("integrationNamedParameterJdbcTemplate") final NamedParameterJdbcTemplate integration) {
         this.integration = integration;
+    }
+
+    public void deleteUnprocessed(final List<Long> maatIds) {
+        final var partitions = partition(maatIds, BATCH_SIZE);
+        final var batchArgs = partitions.stream()
+                .map(partition -> new MapSqlParameterSource("maatIds", partition))
+                .toArray(MapSqlParameterSource[]::new);
+        final int[] rowsDeleted = integration.batchUpdate("""
+                DELETE
+                FROM case_migration
+                WHERE is_processed <> TRUE
+                AND maat_id IN (:maatIds)
+                """, batchArgs);
+        log.info("deleteUnprocessed: Deleted {} rows", Arrays.stream(rowsDeleted).sum());
+    }
+
+    /**
+     * Break a list of elements of size >= 1 into multiple lists, each having a given length
+     * (except possibly the last list, which may be smaller).
+     *
+     * @param input The large list to break into sublists.
+     * @param partitionSize The desired length of the sublists.
+     * @return A list of lists (each of size partitionSize, except perhaps the last).
+     * @param <T> The type of the list.
+     */
+    private <T> List<List<T>> partition(final List<T> input, final int partitionSize) {
+        if (partitionSize < 1) {
+            throw new IllegalArgumentException("partitionSize must be >= 1");
+        }
+        final int inputSize = input.size();
+        final var output = new ArrayList<List<T>>((inputSize + partitionSize - 1) / partitionSize);
+        for (int index = 0; index < inputSize; index += partitionSize) {
+            output.add(input.subList(index, Math.min(index + partitionSize, inputSize)));
+        }
+        return output;
     }
 
     public void removeExisting(final Collection<CaseMigration> caseMigrations) {
@@ -41,7 +80,7 @@ public class CaseMigrationRepository {
     }
 
     public void saveAll(final Collection<CaseMigration> caseMigrations) {
-        integration.batchUpdate("""
+        final int[][] rowsInserted = integration.getJdbcOperations().batchUpdate("""
                 INSERT INTO case_migration (maat_id, record_type, concor_contribution_id, fdc_id,
                                             batch_id, is_processed, processed_date, http_status, payload)
                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
@@ -81,5 +120,6 @@ public class CaseMigrationRepository {
                 stmt.setNull(9, Types.VARCHAR);
             }
         });
+        log.info("saveAll: Inserted {} rows", Arrays.stream(rowsInserted).flatMapToInt(Arrays::stream).sum());
     }
 }

--- a/premigconcor/src/test/java/uk/gov/justice/laadces/premigconcor/dao/integration/CaseMigrationRepositoryTests.java
+++ b/premigconcor/src/test/java/uk/gov/justice/laadces/premigconcor/dao/integration/CaseMigrationRepositoryTests.java
@@ -1,0 +1,24 @@
+package uk.gov.justice.laadces.premigconcor.dao.integration;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class CaseMigrationRepositoryTests {
+    @Autowired
+    CaseMigrationRepository caseMigrationRepository;
+
+    @Test
+    void testPartition() {
+        final var large = List.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+        final var split = caseMigrationRepository.partition(large, 3);
+        assertThat(split).hasSize(4);
+        assertThat(split).isEqualTo(List.of(List.of(1, 2, 3), List.of(4, 5, 6), List.of(7, 8, 9), List.of(10)));
+        assertThat(split.stream().flatMap(List::stream).toList()).hasSize(10);
+    }
+}

--- a/premigconcor/src/test/java/uk/gov/justice/laadces/premigconcor/dao/migration/MaatIdTests.java
+++ b/premigconcor/src/test/java/uk/gov/justice/laadces/premigconcor/dao/migration/MaatIdTests.java
@@ -1,0 +1,16 @@
+package uk.gov.justice.laadces.premigconcor.dao.migration;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MaatIdTests {
+    @Test
+    void testOf() {
+        final var maatIds = MaatId.of(List.of(1L, 2L, 3L));
+        assertThat(maatIds).hasSize(3);
+        assertThat(maatIds).isEqualTo(List.of(new MaatId(1L), new MaatId(2L), new MaatId(3L)));
+    }
+}

--- a/premigconcor/src/test/java/uk/gov/justice/laadces/premigconcor/service/CaseMigrationComponentComparatorTests.java
+++ b/premigconcor/src/test/java/uk/gov/justice/laadces/premigconcor/service/CaseMigrationComponentComparatorTests.java
@@ -1,0 +1,20 @@
+package uk.gov.justice.laadces.premigconcor.service;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Comparator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CaseMigrationComponentComparatorTests {
+    private final Comparator<String> comparator = CaseMigrationComponentComparator.INSTANCE;
+
+    @Test
+    void testCompare() {
+        // this is used to order the columns in the CSV output file of CaseMigration rows.
+        assertThat(comparator.compare("maatId", "fdcId")).isLessThan(0); // maatId is to the left of fdcId
+        assertThat(comparator.compare("maatId", "concorContributionId")).isLessThan(0); // maatId is to the left of fdcId
+        assertThat(comparator.compare("isProcessed", "processedDate")).isLessThan(0); // isProcessed is to the left of processedDate
+        assertThat(comparator.compare("payload", "aardvark")).isLessThan(0); // unknown fields go to the right
+    }
+}


### PR DESCRIPTION
Delete unprocessed records to avoid having multiple migrations per-maatId